### PR TITLE
ClonEvol_surrogate problem

### DIFF
--- a/R/CCF_trees_functions.R
+++ b/R/CCF_trees_functions.R
@@ -233,21 +233,24 @@ ClonEvol_surrogate = function(clusters, samples, clonal.cluster, min.CCF = 0.01)
                    {
                      # check the clonal cluster
                      subclonal.clusters = setdiff(names(w), clonal.cluster)
-
-                     if(length(subclonal.clusters) > 0 & !all(w[clonal.cluster] >= w[subclonal.clusters])) {
+                     
+                     if(is.na(length(subclonal.clusters) > 0 & !all(w[clonal.cluster] >= w[subclonal.clusters]))) {
+                       warning(
+                         'print some message and exit')
+                     } else if(length(subclonal.clusters) > 0 & !all(w[clonal.cluster] >= w[subclonal.clusters])) {
                        warning(
                          '[CORRECTION] The clonal cluster has CCF ', w[clonal.cluster],
                          ', lower than a subclonal cluster; we set it to the max in the sample...')
-
+                       
                        w[clonal.cluster] = max(w) + 0.01
+                       
+                       # trees from this sample, it is a list
+                       TR = CCF_phylogeny_univariate(w, clonal.cluster)
+                       
+                       # turn them into the format that the tools expects and remove the temporary WL node
+                       TR = lapply(TR, MatrixToDataFrame)
+                       TR = lapply(TR, function(y){ y = y[y$from != 'WL', , drop = FALSE] })
                      }
-
-                     # trees from this sample, it is a list
-                     TR = CCF_phylogeny_univariate(w, clonal.cluster)
-
-                     # turn them into the format that the tools expects and remove the temporary WL node
-                     TR = lapply(TR, MatrixToDataFrame)
-                     TR = lapply(TR, function(y){ y = y[y$from != 'WL', , drop = FALSE] })
                    }
                    else {
                      warning('[SKIP] One region does not have at least 2 CCF clusters above 1%, and will be skipped.')


### PR DESCRIPTION
Hi @caravagn, I found a weird case (actually when I was running VIBER) which caused this error and resulted in ctree (and VIBER) to crash:
```
Error in if (length(subclonal.clusters) > 0 & !all(w[clonal.cluster] >=  : 
  missing value where TRUE/FALSE needed

```
It turned out it comes from the [ClonEvol_surrogate](https://github.com/caravagnalab/ctree/blob/master/R/CCF_trees_functions.R) function. The problem is when the condition `length(subclonal.clusters) > 0 & !all(w[clonal.cluster] >= w[subclonal.clusters])` results in `NA`. The root of the problem of course lies in the data and in the parameters used for the clustering (this is an "extreme" case where the "clonal" cluster basically doesn't exist) but I'd prefer to get an error message or warning instead of crashing, if possible .
I tried to draft some kind of quick fix and if you think it can be relevant I'm happy to help.